### PR TITLE
Fix: Make sure footer tucks under preceding element in the document flow (adds negative z-index)

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -54,6 +54,8 @@
         color: var(--dark-gray);
         background-color: var(--light-gray);
         margin-top: -2rem;
+        position: relative;
+        z-index: -1;
     }
 
     .app-footer-container {


### PR DESCRIPTION
The `<AppFooter>` element might appear above the content before it in document flow if the preceding content element doesn't allot enough space for the negative margin for the tuck under effect.

This adds a negative `z-index` so that the footer will be tucked under regardless.

Before/After:

<img width="500" alt="Screen Shot 2022-07-05 at 5 07 47 PM" src="https://user-images.githubusercontent.com/980170/177425161-a1d7bf5c-a3f4-43ba-b904-1ecd7dd76adf.png">

<img width="500" alt="Screen Shot 2022-07-05 at 5 07 38 PM" src="https://user-images.githubusercontent.com/980170/177425166-11dcedae-ccb1-4c67-8fff-00cf2ae6fdfe.png">

