### PR TITLE
add alt attribute to cla workdmark

### DIFF
--- a/src/components/CLAWordmark.vue
+++ b/src/components/CLAWordmark.vue
@@ -1,6 +1,6 @@
 <template>
     <a href="https://cla.umn.edu" class="wordmark-link">
-        <img :src="wordmark" />
+        <img :src="wordmark" alt="College of Liberal Arts" />
     </a>
 </template>
 


### PR DESCRIPTION
Adds an alt attribute to the workmark image in case it doesn't appear.

Also: did you need to do anything special for the workmark image to show up inline? I ended up just copy/pasting to the `/public` image folder. 