### PR TITLE
Add navbar-links-right slot to mobile navbar

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -9,6 +9,7 @@
             </div>
             <ul class="mobile-navbar-block" :class="isOpen" >
                 <slot name="navbar-links"></slot>
+                <slot name="navbar-links-right"></slot>
             </ul>
         </div>
         <div class="outer-block">


### PR DESCRIPTION
Currently any links in `navbar-links-right` aren't showing up in mobile view. This adds a slot for `navbar-links-right` in the mobile navbar.
