### PR TITLE
add bold open sans weight

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap");
 
 body {
   font-family: "Open Sans", Arial, sans-serif !important;


### PR DESCRIPTION
This adds bold open sans weight to theme, which resolves an issue where some elements weren't showing up as bolded (in vuepress with new headers).
