### PR TITLE
fix(footer): make footer links clickable

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -55,7 +55,6 @@
         background-color: var(--light-gray);
         margin-top: -2rem;
         position: relative;
-        z-index: -1;
     }
 
     .app-footer-container {


### PR DESCRIPTION
Remove the negative z-index, which [prevents users from clicking on the app footer](https://github.com/UMN-LATIS/ChimeIn2.0/issues/473).

This was originally intended to fix an overlapping footer issue in ChimeIn (see #2 ), but ChimeIn doesn't use the typical post-it component like other CLA apps. With reusable components less is probably more, so it makes sense to solve layout issues in the context of individual app, rather than trying to solve individual app issues in these components.

