### PR TITLE
docs: add instructions to init submodule after first checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ You probably want to wrap all of your components in a `<div class="cla-template-
 
 ## Updating components
 
-To pull changes from the template library into your application, update the submodule:
+If it's the first time you check-out a repo that uses this submodule, you'll need to use --init to initialize:
+
+```
+git submodule update --init --recursive
+```
+
+After that, to pull changes from the template library into your application, update the submodule:
 
 ```git
 git submodule update --recursive --remote


### PR DESCRIPTION
Adding instructions for how to init the submodule after first project clone because I forget.