### PR TITLE
import open sans weight 600

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap");
 
 body {
   font-family: "Open Sans", Arial, sans-serif !important;


### PR DESCRIPTION
This adds open sans font weight of 600 to the Google Fonts imports. Several components use weight 600. If the 600 weight isn't imported by the app using these components, the browser will use 700 (bold) weight, which isn't quite right.

before:
<img width="691" alt="Screen Shot 2022-09-20 at 12 15 16 PM" src="https://user-images.githubusercontent.com/980170/191323039-2293def1-99d9-4133-b95d-af7663ee48b0.png">

after:
<img width="693" alt="Screen Shot 2022-09-20 at 12 15 30 PM" src="https://user-images.githubusercontent.com/980170/191323067-b40095f4-30c8-4077-b55b-4c7a17fc8a46.png">


