### PR TITLE
fix: Navbar doesn't work as standalone component

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umn-latis/cla-vue-template",
-  "version": "1.2.0",
+  "version": "1.2.1-0",
   "description": "Basic layout for CLA (LATIS) VueJS apps",
   "author": "LATIS Technology Architecture",
   "type": "module",

--- a/src/components/CollegeHeader.vue
+++ b/src/components/CollegeHeader.vue
@@ -36,10 +36,11 @@
 import { inject } from "vue";
 import CLAWordmark from "./CLAWordmark.vue";
 import { atBreakpointRefInjectionKey } from "../constants";
+import { useAtBreakpoint } from "../composables/useAtBreakpoint";
 
 withDefaults(
   defineProps<{
-    isMenuOpen: boolean;
+    isMenuOpen?: boolean;
     href?: string;
   }>(),
   {
@@ -48,7 +49,9 @@ withDefaults(
   }
 );
 
-const atBreakpoint = inject(atBreakpointRefInjectionKey);
+const { atBreakpoint: atFallbackBreakpoint } = useAtBreakpoint("always");
+
+const atBreakpoint = inject(atBreakpointRefInjectionKey, atFallbackBreakpoint);
 
 defineEmits<{
   (event: "clickMenu"): void;

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -64,17 +64,27 @@
 </style>
 
 <script setup lang="ts" async>
-import { inject } from "vue";
-import { BREAKPOINTS, atBreakpointRefInjectionKey } from "../constants";
+import { computed, inject, ref } from "vue";
+import { atBreakpointRefInjectionKey, BREAKPOINTS } from "../constants";
+import { useBreakpoints } from "@vueuse/core";
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
-    isOpen: boolean;
+    isOpen?: boolean;
+    fallbackBreakpoint?: keyof typeof BREAKPOINTS;
   }>(),
   {
     isOpen: false,
+    fallbackBreakpoint: "always",
   }
 );
 
-const atBreakpoint = inject(atBreakpointRefInjectionKey);
+const breakpoints = useBreakpoints(BREAKPOINTS);
+const atFallbackBreakpoint = computed(() =>
+  breakpoints.isGreaterOrEqual(props.fallbackBreakpoint)
+);
+
+// injected breakpoint may not be available if used as
+// a standalone component, so fallback to true
+const atBreakpoint = inject(atBreakpointRefInjectionKey, atFallbackBreakpoint);
 </script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -65,24 +65,19 @@
 
 <script setup lang="ts" async>
 import { computed, inject, ref } from "vue";
-import { atBreakpointRefInjectionKey, BREAKPOINTS } from "../constants";
-import { useBreakpoints } from "@vueuse/core";
+import { atBreakpointRefInjectionKey } from "../constants";
+import { useAtBreakpoint } from "../composables/useAtBreakpoint";
 
 const props = withDefaults(
   defineProps<{
     isOpen?: boolean;
-    fallbackBreakpoint?: keyof typeof BREAKPOINTS;
   }>(),
   {
     isOpen: false,
-    fallbackBreakpoint: "always",
   }
 );
 
-const breakpoints = useBreakpoints(BREAKPOINTS);
-const atFallbackBreakpoint = computed(() =>
-  breakpoints.isGreaterOrEqual(props.fallbackBreakpoint)
-);
+const { atBreakpoint: atFallbackBreakpoint } = useAtBreakpoint("always");
 
 // injected breakpoint may not be available if used as
 // a standalone component, so fallback to true

--- a/src/components/NavbarDropdown.vue
+++ b/src/components/NavbarDropdown.vue
@@ -53,17 +53,30 @@
 <script setup lang="ts">
 import NavbarItem from "./NavbarItem.vue";
 import * as Icons from "../icons";
-import { ref, inject } from "vue";
+import { ref, inject, computed } from "vue";
 import { onClickOutside } from "@vueuse/core";
-import { atBreakpointRefInjectionKey } from "../constants";
+import { atBreakpointRefInjectionKey, BREAKPOINTS } from "../constants";
+import { useBreakpoints } from "@vueuse/core";
 
-defineProps<{
-  label: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    label: string;
+    fallbackBreakpoint?: keyof typeof BREAKPOINTS;
+  }>(),
+  {
+    fallbackBreakpoint: "always",
+  }
+);
 
 const isOpen = ref(false);
 const itemContainer = ref<InstanceType<typeof NavbarItem> | null>(null);
-const atBreakpoint = inject(atBreakpointRefInjectionKey);
+
+const breakpoints = useBreakpoints(BREAKPOINTS);
+const atFallbackBreakpoint = computed(() =>
+  breakpoints.isGreaterOrEqual(props.fallbackBreakpoint)
+);
+
+const atBreakpoint = inject(atBreakpointRefInjectionKey, atFallbackBreakpoint);
 
 onClickOutside(itemContainer, () => {
   // if the container is not mounted or the menu is not

--- a/src/components/NavbarDropdown.vue
+++ b/src/components/NavbarDropdown.vue
@@ -55,26 +55,17 @@ import NavbarItem from "./NavbarItem.vue";
 import * as Icons from "../icons";
 import { ref, inject, computed } from "vue";
 import { onClickOutside } from "@vueuse/core";
-import { atBreakpointRefInjectionKey, BREAKPOINTS } from "../constants";
-import { useBreakpoints } from "@vueuse/core";
+import { atBreakpointRefInjectionKey } from "../constants";
+import { useAtBreakpoint } from "../composables/useAtBreakpoint";
 
-const props = withDefaults(
-  defineProps<{
-    label: string;
-    fallbackBreakpoint?: keyof typeof BREAKPOINTS;
-  }>(),
-  {
-    fallbackBreakpoint: "always",
-  }
-);
+defineProps<{
+  label: string;
+}>();
 
 const isOpen = ref(false);
 const itemContainer = ref<InstanceType<typeof NavbarItem> | null>(null);
 
-const breakpoints = useBreakpoints(BREAKPOINTS);
-const atFallbackBreakpoint = computed(() =>
-  breakpoints.isGreaterOrEqual(props.fallbackBreakpoint)
-);
+const { atBreakpoint: atFallbackBreakpoint } = useAtBreakpoint("always");
 
 const atBreakpoint = inject(atBreakpointRefInjectionKey, atFallbackBreakpoint);
 

--- a/src/composables/useAtBreakpoint.ts
+++ b/src/composables/useAtBreakpoint.ts
@@ -1,0 +1,10 @@
+import { useBreakpoints } from "@vueuse/core";
+import { BREAKPOINTS } from "../constants";
+import { computed } from "vue";
+
+export const useAtBreakpoint = (breakpoint: keyof typeof BREAKPOINTS) => {
+  const breakpoints = useBreakpoints(BREAKPOINTS);
+  const atBreakpoint = computed(() => breakpoints.isGreaterOrEqual(breakpoint));
+
+  return { atBreakpoint };
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import type { InjectionKey, Ref } from "vue";
 
 export const BREAKPOINTS = {
+  always: 0,
   sm: 640,
   md: 768,
   lg: 1024,


### PR DESCRIPTION
This gives the injected `atBreakpoint` value a fallback value so that Navbar can be used as a standalone component

## Background

In release `1.1.0` we introduced better breakpoint detection to handle navbars with a lot of options (like Bluesheet) – those navbars run out of screen real estate faster, and should switch to the collapsible mobile nav sooner.

Because a number of different components needed to use the same breakpoint property info (menu button, mobile nav, dropdown, navbar) This was implemented using provide/injects to avoid prop drilling. The `<AppHeader>` provided the boolean ref `atBreakpoint` to any children.

This prevents using `<Navbar>` as a standalone component, as it won't have access to the provided `atBreakpoint` value if it's not within an `<AppHeader>`

The fix is to give the `inject` function a fallback breakpoint value `always`, meaning it the navbar will always show if a breakpoint is not defined.