### PR TITLE
fix: content shifts when using dropdowns with scroll-lock

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,6 +7,7 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  layout: "fullscreen",
   backgrounds: {
     default: "umn-neutral-bg",
     values: [

--- a/src/index.css
+++ b/src/index.css
@@ -14,11 +14,11 @@ html {
 }
 
 body {
-  font-family: "Open Sans", Arial, sans-serif !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  background-color: var(--main-bg-color) !important;
-  line-height: 1.4 !important;
+  font-family: "Open Sans", Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: var(--main-bg-color);
+  line-height: 1.4;
 }
 
 .cla-template-wrapper {


### PR DESCRIPTION
removes `!important` on body css, so that app css can override if needed (like with dropdowns using scroll-lock).

I suspect the original intent was to avoid the padding that storybook adds to components by default, so the storybook config is updated to include `layout: "fullscreen"`, which overrides the default `layout: "padded"` setting.

fixes #24