### PR TITLE
revert !important changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umn-latis/cla-vue-template",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Basic layout for CLA (LATIS) VueJS apps",
   "author": "LATIS Technology Architecture",
   "type": "module",

--- a/src/index.css
+++ b/src/index.css
@@ -14,11 +14,11 @@ html {
 }
 
 body {
-  font-family: "Open Sans", Arial, sans-serif;
-  margin: 0;
-  padding: 0;
-  background-color: var(--main-bg-color);
-  line-height: 1.4;
+  font-family: "Open Sans", Arial, sans-serif !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  background-color: var(--main-bg-color) !important;
+  line-height: 1.4 !important;
 }
 
 .cla-template-wrapper {


### PR DESCRIPTION
It looks like some of our apps might depend on this being `!important`. For instance, BlueSheet's font and line-height will fallback to bootstrap's default without the `!important`.

Thus, this is probably a breaking change, and not a patch change. Gonna release as a major change to avoid accidental updates.