### PR TITLE
reduce z-index of yellow "post-it" tape

### DIFF
--- a/src/components/PostIt.vue
+++ b/src/components/PostIt.vue
@@ -43,7 +43,7 @@
     left: calc(50% - 55px);
     top: -8px;
     background-color: var(--gold);
-    z-index: 100;
+    z-index: 1;
 }
 
 </style>


### PR DESCRIPTION
Fixes #21

z-index prob isn't needed at all since absolute positioned items are drawn after static in the same stacking context, but just in case we'll leave it as 1.
