### PR TITLE
fix navbar dropdown transparency

### DIFF
--- a/src/components/NavbarDropdown.vue
+++ b/src/components/NavbarDropdown.vue
@@ -4,7 +4,7 @@
       :id="triggerButtonId"
       @click="toggleDropdown"
       @keydown="handleKeydown"
-      class="navbar-dropdown__button tw-flex tw-w-full tw-h-full tw-px-5 tw-items-center tw-gap-2 tw-whitespace-nowrap tw-justify-between tw-border-0 tw-text-base hover:tw-bg-umn-neutral-200"
+      class="navbar-dropdown__button tw-flex tw-w-full tw-h-full tw-px-5 tw-items-center tw-gap-2 tw-whitespace-nowrap tw-justify-between tw-border-0 tw-text-base hover:tw-bg-umn-neutral-200 tw-bg-transparent"
       :class="{
         'navbar-dropdown__button--is-open tw-text-umn-maroon tw-bg-neutral-200':
           isOpen,

--- a/src/index.css
+++ b/src/index.css
@@ -49,15 +49,3 @@ body {
   --light-black: var(--umn-neutral-800);
   --nav-item-active: var(--umn-neutral-200);
 }
-
-.debug-blue {
-  border: 1px solid blue;
-}
-
-.debug-red {
-  border: 1px solid red;
-}
-
-button {
-  background: transparent;
-}


### PR DESCRIPTION
In safari (tahoe only?), the dropdown nav button has an extra background which gives it a darker appearance. Originally, this was fixed by setting a default `button { background: transparent; }` but this clobbered all button backgounds.

This fix, scopes the transparency properly to the dropdown button by adding a CSS class and then removes the previous fix.

Before / After

<img width="400" alt="ScreenShot 2026-02-09 at 11 42 10@2x" src="https://github.com/user-attachments/assets/0ece2b38-d457-4a4b-8a69-3774a501ae51" />

<img width="400"  alt="ScreenShot 2026-02-09 at 11 56 13@2x" src="https://github.com/user-attachments/assets/88689cf9-7f6b-4ab4-9542-eb81dad32a94" />

